### PR TITLE
Tab support

### DIFF
--- a/browser-client/webkit.py
+++ b/browser-client/webkit.py
@@ -240,9 +240,9 @@ document.getElementById('link-{REVKEYS[event.keyval]+tab.first_link}').href
             self.notebook.next_page()
         elif alt and event.keyval == Gdk.KEY_Page_Down:
             self.notebook.next_page()
-        elif event.keyval in (Gdk.KEY_BackSpace, Gdk.KEY_comma, Gdk.KEY_less, Gdk.KEY_b, Gdk.KEY_Prior):
+        elif event.keyval in (Gdk.KEY_BackSpace, Gdk.KEY_comma, Gdk.KEY_less, Gdk.KEY_b):
             tab.webview.go_back()
-        elif event.keyval in (Gdk.KEY_period, Gdk.KEY_greater, Gdk.KEY_f, Gdk.KEY_Next):
+        elif event.keyval in (Gdk.KEY_period, Gdk.KEY_greater, Gdk.KEY_f):
             tab.webview.go_forward()
         elif event.keyval in (Gdk.KEY_F5, Gdk.KEY_r):
             tab.webview.reload()

--- a/browser-client/webkit.py
+++ b/browser-client/webkit.py
@@ -223,28 +223,26 @@ document.getElementById('link-{REVKEYS[event.keyval]+tab.first_link}').href
 """, None, _new_tab_callback)
             elif alt:
                 self.notebook.set_current_page(REVKEYS[event.keyval])
-        elif event.keyval == Gdk.KEY_t:
+        elif event.keyval in (Gdk.KEY_t, Gdk.KEY_Insert):
             self._open_new_tab(tab.url)
-        elif event.keyval == Gdk.KEY_w:
-            self._close_current_tab()
-        elif event.keyval == Gdk.KEY_Insert:
-            self._open_new_tab(tab.url)
-        elif event.keyval == Gdk.KEY_Delete:
+        elif event.keyval in (Gdk.KEY_w, Gdk.KEY_Delete):
             self._close_current_tab()
         elif event.keyval == Gdk.KEY_Tab:
             if ctrl or not event.state:
                 self.notebook.next_page()
             elif shift:
                 self.notebook.prev_page()
-        elif event.keyval == Gdk.KEY_ISO_Left_Tab:
+        elif event.keyval in (Gdk.KEY_ISO_Left_Tab, Gdk.KEY_grave, Gdk.KEY_bracketleft, Gdk.KEY_p):
             self.notebook.prev_page()
-        elif event.keyval == Gdk.KEY_grave:
+        elif alt and event.keyval == Gdk.KEY_Page_Up:
             self.notebook.prev_page()
-        elif event.keyval == Gdk.KEY_BackSpace:
+        elif event.keyval in (Gdk.KEY_bracketright, Gdk.KEY_n):
+            self.notebook.next_page()
+        elif alt and event.keyval == Gdk.KEY_Page_Down:
+            self.notebook.next_page()
+        elif event.keyval in (Gdk.KEY_BackSpace, Gdk.KEY_comma, Gdk.KEY_less, Gdk.KEY_b, Gdk.KEY_Prior):
             tab.webview.go_back()
-        elif event.keyval in (Gdk.KEY_comma, Gdk.KEY_less):
-            tab.webview.go_back()
-        elif event.keyval in (Gdk.KEY_period, Gdk.KEY_greater):
+        elif event.keyval in (Gdk.KEY_period, Gdk.KEY_greater, Gdk.KEY_f, Gdk.KEY_Next):
             tab.webview.go_forward()
         elif event.keyval in (Gdk.KEY_F5, Gdk.KEY_r):
             tab.webview.reload()


### PR DESCRIPTION
Adds support for multiple tabs: resolves #1.

- Ctrl + T opens a new tab. (T on its own also opens a new tab, as does Insert.)
- Ctrl + W, or W, closes one tab, but not the whole browser, as does Delete.
- Ctrl + Q, or Q, closes the browser, as does Escape.
- Ctrl + digit opens the link in a new tab.
- Alt + digit switches tabs to a specific index.
- Alt + PageUp and Alt + PageDown move up and down the tabs, as do 'p' and 'n' and Tab and Shift-Tab and Ctrl-Tab and backtick.
- < and > additionally move back and forward, as do 'b' and 'f'.
- H gets you a kitten.

In return, the letter keys no longer follow links. See #4 .
In the end I figured the well-known Ctrl-letter combinations were important and I wanted Ctrl-link key to always work.

I haven't figured out how to reach out from webkit to make a new tab happen. See #3 .

